### PR TITLE
com.ollamapilot: exclude plugin

### DIFF
--- a/generator/src/plugins.rs
+++ b/generator/src/plugins.rs
@@ -258,6 +258,8 @@ fn hacks_for_details_key(pluginkey: &str) -> Option<&str> {
         "io.github.kings1990.FastRequest" => None,
         // ZIP contains invalid file names
         "com.majera.intellij.codereview.gitlab" => None,
+        // ZIP contains invalid file names
+        "com.ollamapilot" => None,
         v => Some(v),
     }
 }


### PR DESCRIPTION
```
error: cannot get archive member name: Pathname cannot be converted from UTF-8 to current locale.
2026-07-04T06:30:57.481571756+00:00 WARN nix_jebrains_plugins_generator::plugins - failed plugin processing com.ollamapilot: nix-prefetch-url failed for https://downloads.marketplace.jetbrains.com/files/32539/1095102/AI__-0.1.8.zip. Might retry.
```