### PR TITLE
gha: remove overrides checks on darwin x86

### DIFF
--- a/.github/workflows/overrides.yml
+++ b/.github/workflows/overrides.yml
@@ -82,7 +82,6 @@ jobs:
         os:
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-26-intel
           - macos-26
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
The platform is now no longer supported by nixpkgs on unstable.