### PR TITLE
fix(com.intellij.nativeDebug): Add missing liblldb

### DIFF
--- a/overrides/com.intellij.nativeDebug/default.nix
+++ b/overrides/com.intellij.nativeDebug/default.nix
@@ -1,0 +1,11 @@
+{
+  stdenv,
+  lib,
+  lldb,
+}:
+origPlugin:
+origPlugin.overrideAttrs (old: {
+  buildInputs = old.buildInputs or [ ] ++ lib.optionals stdenv.hostPlatform.isLinux [ lldb ];
+
+  meta.maintainers = [ "provokateurin" ];
+})


### PR DESCRIPTION
```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/hf6ryl86gricz8919a1mh1bfja1rigfh-com.intellij.nativeDebug-262.8665.176
source root is com.intellij.nativeDebug-262.8665.176
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/37xc1xbmpn6zfx7v7j1jl8ag7p42frgr-com.intellij.nativeDebug-262.8665.176
shrinking /nix/store/37xc1xbmpn6zfx7v7j1jl8ag7p42frgr-com.intellij.nativeDebug-262.8665.176/bin/lldb/linux/aarch64/bin/LLDBFrontend
shrinking /nix/store/37xc1xbmpn6zfx7v7j1jl8ag7p42frgr-com.intellij.nativeDebug-262.8665.176/bin/lldb/linux/x64/bin/LLDBFrontend
checking for references to /build/ in /nix/store/37xc1xbmpn6zfx7v7j1jl8ag7p42frgr-com.intellij.nativeDebug-262.8665.176...
patching script interpreter paths in /nix/store/37xc1xbmpn6zfx7v7j1jl8ag7p42frgr-com.intellij.nativeDebug-262.8665.176
stripping (with command strip and flags -S -p) in  /nix/store/37xc1xbmpn6zfx7v7j1jl8ag7p42frgr-com.intellij.nativeDebug-262.8665.176/lib /nix/store/37xc1xbmpn6zfx7v7j1jl8ag7p42frgr-com.intellij.nativeDebug-262.8665.176/bin
automatically fixing dependencies for ELF files
{'add_existing': True,
 'append_rpaths': [],
 'extra_args': [],
 'ignore_missing': [],
 'keep_libc': False,
 'libs': [PosixPath('/nix/store/i606i6a4i07gxlrcgik75p67ybiiraqv-auto-patchelf-hook/lib'),
          PosixPath('/nix/store/pckdgk97zn0pyddffwyz4iycvxqvxw0a-auto-patchelf-0-unstable-2024-08-14/lib'),
          PosixPath('/nix/store/mgcs1sc02mrk3c6kf84b032ryzgg1y8s-binutils-wrapper-2.46/lib'),
          PosixPath('/nix/store/rjldc9vyg065shsz7bvpy4rfpa9qah29-patchelf-0.15.2/lib'),
          PosixPath('/nix/store/4lgz3nanbs329m2jc63lmyq6q2q2pvga-update-autotools-gnu-config-scripts-hook/lib'),
          PosixPath('/nix/store/0y5xmdb7qfvimjwbq7ibg1xdgkgjwqng-no-broken-symlinks.sh/lib'),
          PosixPath('/nix/store/cv1d7p48379km6a85h4zp6kr86brh32q-audit-tmpdir.sh/lib'),
          PosixPath('/nix/store/85clx3b0xkdf58jn161iy80y5223ilbi-compress-man-pages.sh/lib'),
          PosixPath('/nix/store/p3l1a5y7nllfyrjn2krlwgcc3z0cd3fq-make-symlinks-relative.sh/lib'),
          PosixPath('/nix/store/5yzw0vhkyszf2d179m0qfkgxmp5wjjx4-move-docs.sh/lib'),
          PosixPath('/nix/store/fyaryjvghbkpfnsyw97hb3lyb37s1pd6-move-lib64.sh/lib'),
          PosixPath('/nix/store/kd4xwxjpjxi71jkm6ka0np72if9rm3y0-move-sbin.sh/lib'),
          PosixPath('/nix/store/pag6l61paj1dc9sv15l7bm5c17xn5kyk-move-systemd-user-units.sh/lib'),
          PosixPath('/nix/store/cmzya9irvxzlkh7lfy6i82gbp0saxqj3-multiple-outputs.sh/lib'),
          PosixPath('/nix/store/x8c40nfigps493a07sdr2pm5s9j1cdc0-patch-shebangs.sh/lib'),
          PosixPath('/nix/store/cickvswrvann041nqxb0rxilc46svw1n-prune-libtool-files.sh/lib'),
          PosixPath('/nix/store/xyff06pkhki3qy1ls77w10s0v79c9il0-reproducible-builds.sh/lib'),
          PosixPath('/nix/store/z7k98578dfzi6l3hsvbivzm7hfqlk0zc-set-source-date-epoch-to-latest.sh/lib'),
          PosixPath('/nix/store/pilsssjjdxvdphlg2h19p0bfx5q0jzkn-strip.sh/lib'),
          PosixPath('/nix/store/cnggn0p188nfvys53iqsavf2agpykdh2-gcc-wrapper-15.2.0/lib'),
          PosixPath('/nix/store/sy6f3dwky722534749nv3ccwfic1zsdv-binutils-wrapper-2.46/lib'),
          PosixPath('/nix/store/7vafhlh0lmcvi75jfyy09qwr4m3x1ks3-gcc-15.2.0-lib/lib'),
          PosixPath('/nix/store/i606i6a4i07gxlrcgik75p67ybiiraqv-auto-patchelf-hook/lib'),
          PosixPath('/nix/store/pckdgk97zn0pyddffwyz4iycvxqvxw0a-auto-patchelf-0-unstable-2024-08-14/lib'),
          PosixPath('/nix/store/mgcs1sc02mrk3c6kf84b032ryzgg1y8s-binutils-wrapper-2.46/lib'),
          PosixPath('/nix/store/rjldc9vyg065shsz7bvpy4rfpa9qah29-patchelf-0.15.2/lib'),
          PosixPath('/nix/store/4lgz3nanbs329m2jc63lmyq6q2q2pvga-update-autotools-gnu-config-scripts-hook/lib'),
          PosixPath('/nix/store/0y5xmdb7qfvimjwbq7ibg1xdgkgjwqng-no-broken-symlinks.sh/lib'),
          PosixPath('/nix/store/cv1d7p48379km6a85h4zp6kr86brh32q-audit-tmpdir.sh/lib'),
          PosixPath('/nix/store/85clx3b0xkdf58jn161iy80y5223ilbi-compress-man-pages.sh/lib'),
          PosixPath('/nix/store/p3l1a5y7nllfyrjn2krlwgcc3z0cd3fq-make-symlinks-relative.sh/lib'),
          PosixPath('/nix/store/5yzw0vhkyszf2d179m0qfkgxmp5wjjx4-move-docs.sh/lib'),
          PosixPath('/nix/store/fyaryjvghbkpfnsyw97hb3lyb37s1pd6-move-lib64.sh/lib'),
          PosixPath('/nix/store/kd4xwxjpjxi71jkm6ka0np72if9rm3y0-move-sbin.sh/lib'),
          PosixPath('/nix/store/pag6l61paj1dc9sv15l7bm5c17xn5kyk-move-systemd-user-units.sh/lib'),
          PosixPath('/nix/store/cmzya9irvxzlkh7lfy6i82gbp0saxqj3-multiple-outputs.sh/lib'),
          PosixPath('/nix/store/x8c40nfigps493a07sdr2pm5s9j1cdc0-patch-shebangs.sh/lib'),
          PosixPath('/nix/store/cickvswrvann041nqxb0rxilc46svw1n-prune-libtool-files.sh/lib'),
          PosixPath('/nix/store/xyff06pkhki3qy1ls77w10s0v79c9il0-reproducible-builds.sh/lib'),
          PosixPath('/nix/store/z7k98578dfzi6l3hsvbivzm7hfqlk0zc-set-source-date-epoch-to-latest.sh/lib'),
          PosixPath('/nix/store/pilsssjjdxvdphlg2h19p0bfx5q0jzkn-strip.sh/lib'),
          PosixPath('/nix/store/cnggn0p188nfvys53iqsavf2agpykdh2-gcc-wrapper-15.2.0/lib'),
          PosixPath('/nix/store/sy6f3dwky722534749nv3ccwfic1zsdv-binutils-wrapper-2.46/lib'),
          PosixPath('/nix/store/7vafhlh0lmcvi75jfyy09qwr4m3x1ks3-gcc-15.2.0-lib/lib')],
 'paths': [PosixPath('/nix/store/37xc1xbmpn6zfx7v7j1jl8ag7p42frgr-com.intellij.nativeDebug-262.8665.176')],
 'preserve_origin': False,
 'recursive': True,
 'runtime_dependencies': [],
 'structured_logs': False}
setting interpreter of /nix/store/37xc1xbmpn6zfx7v7j1jl8ag7p42frgr-com.intellij.nativeDebug-262.8665.176/bin/lldb/linux/x64/bin/LLDBFrontend
searching for dependencies of /nix/store/37xc1xbmpn6zfx7v7j1jl8ag7p42frgr-com.intellij.nativeDebug-262.8665.176/bin/lldb/linux/x64/bin/LLDBFrontend
    liblldb.so -> not found!
    libstdc++.so.6 -> found: /nix/store/7vafhlh0lmcvi75jfyy09qwr4m3x1ks3-gcc-15.2.0-lib/lib
    libgcc_s.so.1 -> found: /nix/store/pvc1kn4r39y8jk0wskzl8rb4m6jmy4fp-gcc-15.2.0-libgcc/lib
setting RPATH to: /nix/store/7vafhlh0lmcvi75jfyy09qwr4m3x1ks3-gcc-15.2.0-lib/lib:/nix/store/pvc1kn4r39y8jk0wskzl8rb4m6jmy4fp-gcc-15.2.0-libgcc/lib
skipping /nix/store/37xc1xbmpn6zfx7v7j1jl8ag7p42frgr-com.intellij.nativeDebug-262.8665.176/bin/lldb/linux/aarch64/bin/LLDBFrontend because its architecture (AArch64) differs from target (x64)
auto-patchelf: 1 dependencies could not be satisfied
error: auto-patchelf could not satisfy dependency liblldb.so wanted by /nix/store/37xc1xbmpn6zfx7v7j1jl8ag7p42frgr-com.intellij.nativeDebug-262.8665.176/bin/lldb/linux/x64/bin/LLDBFrontend
auto-patchelf failed to find all the required dependencies.
Add the missing dependencies to --libs or use `--ignore-missing="foo.so.1 bar.so etc.so"`.
```